### PR TITLE
Automatic Reinit

### DIFF
--- a/ArduinoNunchuk/ArduinoNunchuk.cpp
+++ b/ArduinoNunchuk/ArduinoNunchuk.cpp
@@ -22,36 +22,30 @@ void ArduinoNunchuk::init()
 {
   Wire.begin();
   ArduinoNunchuk::reinit();
-
 }
 void ArduinoNunchuk::reinit()
 {
   //init the nunchuk 
+  ArduinoNunchuk::official = true;
   ArduinoNunchuk::_sendByte(0x55, 0xF0);
   delay(10);
   ArduinoNunchuk::_sendByte(0x00, 0xFB);
   delay(10);
- 
+  ArduinoNunchuk::_sendByte(0x00, 0x00);
+  delay(10);
   ArduinoNunchuk::update();
-  
-
 }
 
 void ArduinoNunchuk::update()
 {
-
-
-  //prime the nunchuk for reading data
-  //this needs to be immediately before reading data or
-  //some controllers will send corrupt data
-  //(memorex in particular)
-  //dont put at end of function
-
-  ArduinoNunchuk::_sendByte(0x00, 0x00);
-
   uint8_t count = 0;      
   uint8_t values[6];
   uint8_t errors = 0;
+
+  //third party nunchuk needs to be primed for next cycle here
+  if(ArduinoNunchuk::official== false) {
+    ArduinoNunchuk::_sendByte(0x00, 0x00);
+  }
 
   Wire.requestFrom(ADDRESS, 6);
 
@@ -66,16 +60,17 @@ void ArduinoNunchuk::update()
   //detect receiving only partial data.
   if(count != 6) {
     ArduinoNunchuk::pluggedin = false;
+    ArduinoNunchuk::official = true;
     return;
   }
 
   //detect the nunchuk being unplugged and attempt to reconnect.
-  
   if(errors >= 6) {
     ArduinoNunchuk::reinit();
     return;
   }
-  
+
+  //calculate values
   ArduinoNunchuk::analogX = values[0];
   ArduinoNunchuk::analogY = values[1];
   ArduinoNunchuk::accelX = (values[2] << 2) | ((values[5] >> 2) & 3);
@@ -83,28 +78,30 @@ void ArduinoNunchuk::update()
   ArduinoNunchuk::accelZ = (values[4] << 2) | ((values[5] >> 6) & 3);
   ArduinoNunchuk::zButton = !((values[5] >> 0) & 1);
   ArduinoNunchuk::cButton = !((values[5] >> 1) & 1);
- 
 
-//this check can't go in the init section because some controllers do not get re-init on a hot plug (memorex)
-
-if(ArduinoNunchuk::pluggedin == false){
-ArduinoNunchuk::pluggedin = true;
-  ArduinoNunchuk::analogXcenter = ArduinoNunchuk::analogX;
-  ArduinoNunchuk::analogYcenter = ArduinoNunchuk::analogY;
-}
+  //this check can't go in the init section because some 3rd party nunchuks do not get re-init on a hot plug
+  //detecting this is a good way to tell if a nunchuk is official or not
+  if(ArduinoNunchuk::pluggedin == false){
+    ArduinoNunchuk::pluggedin = true;
+    ArduinoNunchuk::official = false;
+    ArduinoNunchuk::analogXcenter = ArduinoNunchuk::analogX;
+    ArduinoNunchuk::analogYcenter = ArduinoNunchuk::analogY;
+  }
 
   ArduinoNunchuk::analogMagnitude = sqrt(pow((ArduinoNunchuk::analogXcenter-ArduinoNunchuk::analogX),2)+pow((ArduinoNunchuk::analogYcenter-ArduinoNunchuk::analogY),2));
   ArduinoNunchuk::analogAngle = (atan2(ArduinoNunchuk::analogYcenter-ArduinoNunchuk::analogY,ArduinoNunchuk::analogXcenter-ArduinoNunchuk::analogX)*57.2957);
+
+  //official nintendo nunchuk needs to be primed for next cycle here
+  if(ArduinoNunchuk::official == true) {
+    ArduinoNunchuk::_sendByte(0x00, 0x00);
+  }
 
 }
 
 void ArduinoNunchuk::_sendByte(byte data, byte location)
 {
   Wire.beginTransmission(ADDRESS);
-
   Wire.write(location);
   Wire.write(data);
-
   Wire.endTransmission();
-
 }

--- a/ArduinoNunchuk/ArduinoNunchuk.h
+++ b/ArduinoNunchuk/ArduinoNunchuk.h
@@ -19,26 +19,27 @@
 
 class ArduinoNunchuk
 {
-  public:
-    uint8_t analogXcenter;
-    uint8_t analogYcenter;
-    uint8_t analogX;
-    uint8_t analogY;
-    int analogMagnitude;
-    int analogAngle;
-    int accelX;
-    int accelY;
-    int accelZ;
-    boolean zButton;
-    boolean cButton;
-    boolean pluggedin;
-    
-    void init();
-    void update();
+public:
+  uint8_t analogXcenter;
+  uint8_t analogYcenter;
+  uint8_t analogX;
+  uint8_t analogY;
+  int analogMagnitude;
+  int analogAngle;
+  int accelX;
+  int accelY;
+  int accelZ;
+  boolean zButton;
+  boolean cButton;
+  boolean pluggedin;
 
-  private:
-    void reinit();
-    void _sendByte(byte data, byte location);
+  void init();
+  void update();
+
+private:
+  boolean official;
+  void reinit();
+  void _sendByte(byte data, byte location);
 };
 
 #endif


### PR DESCRIPTION
1: If only 0xFF is received from the Nunchuk a reinit is automatically attempted.

2: If only partial data is received the sensor values won't be updated.

3: The transmission delay was moved to init() only.  I'm not sure how much of a delay is needed in the init, but program code should provide the delay at the end of update().

4: Changed some ints to uint8_t.  Didn't look like a full int was needed, and it uses less ram and generates smaller code.
